### PR TITLE
fix: ref worker URL properly

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['airbnb', 'prettier'],
   plugins: ['prettier', 'jest'],
+  parserOptions: { ecmaVersion: 2020 },
   rules: {
     indent: ['error', 2],
     'prettier/prettier': ['error', { endOfLine: 'auto' }],

--- a/bin.js
+++ b/bin.js
@@ -130,7 +130,8 @@ yargs(hideBin(process.argv))
       const { verbose, api, source, target, key, url, remappedFilenames, threads = 4 } = argv;
 
       const maxWorkers = Math.min(remappedFilenames.length, threads);
-      const workers = [...new Array(maxWorkers)].map(() => new Worker('./src/worker.js'));
+      const workerURL = new URL('./src/worker.js', import.meta.url);
+      const workers = [...new Array(maxWorkers)].map(() => new Worker(workerURL));
 
       const startWorker = (worker, index) => {
         console.log(head.bold(remappedFilenames[index]), head('- beginning translation'));


### PR DESCRIPTION
Issue with worker URL being a relative path causing it not to be sourced properly when the package was installed. Fixed with use of URL object and `import.meta.url` to reference it correctly when installed as package. 